### PR TITLE
Implement website filtering with custom dns

### DIFF
--- a/dns_filter/Kbuild
+++ b/dns_filter/Kbuild
@@ -1,0 +1,2 @@
+obj-m := dns_filter.o
+dns_filter-objs := dns_filter_main.o dns_filter_core.o

--- a/dns_filter/Makefile
+++ b/dns_filter/Makefile
@@ -1,0 +1,64 @@
+# DNS Filter Module for OpenWrt
+# Copyright (c) 2024
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=dns-filter
+PKG_VERSION:=1.0
+PKG_RELEASE:=1
+
+PKG_MAINTAINER:=DNS Filter Team
+PKG_LICENSE:=GPL-2.0
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/kernel.mk
+
+define Package/dns-filter
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=DNS Site Filtering Module
+  DESCRIPTION:=Kernel module for DNS site filtering that works regardless of user DNS settings
+  KCONFIG:=CONFIG_NETFILTER=y CONFIG_NETFILTER_NETLINK=y
+  DEPENDS:=+kmod-ipt-core +kmod-nf-conntrack
+endef
+
+define Package/dns-filter/description
+  This package provides DNS site filtering functionality at the kernel level
+  using netfilter hooks. It can filter DNS requests even when users manually
+  set DNS servers to 114.114.114.114, 8.8.8.8, or other public DNS services.
+endef
+
+define Package/dns-filter/conffiles
+/etc/config/dns-filter
+/etc/dns-filter/blocked-domains.txt
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+	$(MAKE) -C "$(LINUX_DIR)" \
+		CROSS_COMPILE="$(TARGET_CROSS)" \
+		ARCH="$(LINUX_KARCH)" \
+		SUBDIRS="$(PKG_BUILD_DIR)" \
+		EXTRA_CFLAGS="$(BUILDFLAGS)" \
+		modules
+	$(TARGET_CC) $(TARGET_CFLAGS) $(TARGET_LDFLAGS) \
+		-o $(PKG_BUILD_DIR)/dns-filter-ctl \
+		$(PKG_BUILD_DIR)/dns_filter_ctl.c
+endef
+
+define Package/dns-filter/install
+	$(INSTALL_DIR) $(1)/lib/modules/$(LINUX_VERSION)
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/dns_filter.ko $(1)/lib/modules/$(LINUX_VERSION)/
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/dns-filter-ctl $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_DATA) ./files/dns-filter.config $(1)/etc/config/dns-filter
+	$(INSTALL_DIR) $(1)/etc/dns-filter
+	$(INSTALL_DATA) ./files/blocked-domains.txt $(1)/etc/dns-filter/
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/dns-filter.init $(1)/etc/init.d/dns-filter
+endef
+
+$(eval $(call BuildPackage,dns-filter))

--- a/dns_filter/README.md
+++ b/dns_filter/README.md
@@ -1,0 +1,273 @@
+# DNS Filter Module for OpenWrt
+
+一个为OpenWrt系统设计的DNS站点过滤内核模块，能够在用户手动设置DNS为114.114.114.114、8.8.8.8等公共DNS服务器时仍然正常工作。
+
+## 功能特性
+
+- **内核级DNS拦截**: 使用netfilter框架在内核层面拦截所有DNS查询
+- **绕过用户DNS设置**: 即使用户手动设置了公共DNS服务器，过滤功能仍然有效
+- **高性能**: 使用红黑树数据结构快速查找被阻止的域名
+- **子域名匹配**: 阻止父域名时自动阻止所有子域名
+- **统计信息**: 提供详细的查询统计和阻止率信息
+- **动态配置**: 支持运行时添加/删除域名，无需重启
+- **可配置日志**: 可选择性地记录被阻止或允许的查询
+- **UCI集成**: 完全集成OpenWrt的UCI配置系统
+
+## 工作原理
+
+本模块通过以下方式实现DNS过滤：
+
+1. **Netfilter Hook**: 在`NF_INET_PRE_ROUTING`阶段注册netfilter钩子
+2. **DNS包识别**: 检测目标端口为53的UDP包
+3. **DNS解析**: 解析DNS查询包中的域名
+4. **域名匹配**: 在红黑树中快速查找是否需要阻止
+5. **包处理**: 阻止匹配的查询包，允许其他包通过
+
+这种方法确保了无论用户设置什么DNS服务器，所有DNS查询都会被检查和过滤。
+
+## 安装
+
+### 1. 编译环境准备
+
+确保您有OpenWrt的构建环境，并且已经编译了内核。
+
+### 2. 添加包到OpenWrt
+
+将整个`dns_filter`目录复制到OpenWrt源码的`package/kernel/`目录下：
+
+```bash
+cp -r dns_filter /path/to/openwrt/package/kernel/
+```
+
+### 3. 配置和编译
+
+```bash
+cd /path/to/openwrt
+make menuconfig
+```
+
+在menuconfig中选择：
+```
+Kernel modules --> Network Support --> kmod-dns-filter
+```
+
+然后编译：
+```bash
+make package/kernel/dns_filter/compile
+```
+
+### 4. 安装到设备
+
+将生成的ipk包复制到OpenWrt设备并安装：
+```bash
+opkg install dns-filter_1.0-1_*.ipk
+```
+
+## 使用方法
+
+### 基本操作
+
+```bash
+# 启动DNS过滤服务
+/etc/init.d/dns-filter start
+
+# 查看过滤状态和统计信息
+dns-filter-ctl --status
+
+# 添加要阻止的域名
+dns-filter-ctl --add example.com
+
+# 删除域名
+dns-filter-ctl --remove example.com
+
+# 列出所有被阻止的域名
+dns-filter-ctl --list
+
+# 从文件批量加载域名
+dns-filter-ctl --load /etc/dns-filter/blocked-domains.txt
+
+# 清空所有阻止规则
+dns-filter-ctl --clear
+```
+
+### 配置选项
+
+编辑`/etc/config/dns-filter`：
+
+```
+config dns-filter 'config'
+    option enabled '1'                    # 启用过滤
+    option log_blocked '0'                # 记录被阻止的查询
+    option log_allowed '0'                # 记录允许的查询
+    option block_unknown '0'              # 阻止未知域名
+    option max_domains '10000'            # 最大域名数量
+    option domains_file '/etc/dns-filter/blocked-domains.txt'  # 域名列表文件
+    option auto_load_domains '1'          # 启动时自动加载域名
+```
+
+### 域名配置文件
+
+编辑`/etc/dns-filter/blocked-domains.txt`添加要阻止的域名：
+
+```
+# 每行一个域名
+malware.com
+phishing-site.net
+# 注释以#开头
+doubleclick.net  # 阻止广告
+```
+
+## 高级功能
+
+### 统计信息
+
+```bash
+# 查看详细统计
+dns-filter-ctl --stats
+
+# 查看proc接口
+cat /proc/dns_filter/stats
+cat /proc/dns_filter/config
+cat /proc/dns_filter/domains
+```
+
+### 动态配置
+
+```bash
+# 启用/禁用日志记录
+dns-filter-ctl --log-blocked 1
+dns-filter-ctl --log-allowed 1
+
+# 启用/禁用过滤
+dns-filter-ctl --enable
+dns-filter-ctl --disable
+```
+
+### 服务管理
+
+```bash
+# 启动服务
+/etc/init.d/dns-filter start
+
+# 停止服务
+/etc/init.d/dns-filter stop
+
+# 重启服务
+/etc/init.d/dns-filter restart
+
+# 重新加载配置
+/etc/init.d/dns-filter reload
+
+# 设置开机启动
+/etc/init.d/dns-filter enable
+```
+
+## 监控和调试
+
+### 内核日志
+
+查看内核日志了解模块状态：
+```bash
+dmesg | grep dns_filter
+logread | grep dns-filter
+```
+
+### Proc接口
+
+直接访问proc接口进行调试：
+```bash
+# 查看统计信息
+cat /proc/dns_filter/stats
+
+# 查看配置
+cat /proc/dns_filter/config
+
+# 查看域名列表（格式：域名 命中次数 最后命中时间）
+cat /proc/dns_filter/domains
+
+# 手动添加域名
+echo "add test.com" > /proc/dns_filter/domains
+
+# 手动删除域名
+echo "del test.com" > /proc/dns_filter/domains
+
+# 手动配置
+echo "enabled=1" > /proc/dns_filter/config
+echo "log_blocked=1" > /proc/dns_filter/config
+```
+
+## 性能考虑
+
+- 使用红黑树数据结构确保O(log n)的查找性能
+- 内核级处理避免了用户空间的上下文切换开销
+- 支持大量域名（默认最多10000个）
+- 使用自旋锁保护数据结构，适合高并发环境
+
+## 注意事项
+
+1. **内核兼容性**: 模块需要与内核版本匹配，确保使用正确的内核头文件编译
+2. **内存使用**: 每个被阻止的域名大约占用300字节内存
+3. **网络性能**: 在高流量环境下可能对DNS查询延迟有轻微影响
+4. **安全考虑**: 模块运行在内核空间，确保只从可信来源安装
+
+## 故障排除
+
+### 模块加载失败
+```bash
+# 检查内核版本
+uname -r
+# 检查模块依赖
+lsmod | grep netfilter
+# 手动加载模块
+insmod /lib/modules/$(uname -r)/dns_filter.ko
+```
+
+### 过滤不工作
+```bash
+# 检查模块是否加载
+lsmod | grep dns_filter
+# 检查配置
+dns-filter-ctl --status
+# 检查域名列表
+dns-filter-ctl --list
+```
+
+### 性能问题
+```bash
+# 查看统计信息
+cat /proc/dns_filter/stats
+# 检查系统负载
+top
+# 查看内核日志
+dmesg | tail
+```
+
+## 开发和贡献
+
+本项目采用GPL v2许可证。欢迎提交bug报告和功能请求。
+
+### 编译要求
+- OpenWrt构建环境
+- 对应的内核头文件
+- GCC交叉编译工具链
+
+### 文件结构
+```
+dns_filter/
+├── Makefile              # OpenWrt包Makefile
+├── Kbuild               # 内核模块构建文件
+├── dns_filter.h         # 头文件
+├── dns_filter_main.c    # 主模块文件
+├── dns_filter_core.c    # 核心功能实现
+├── dns_filter_ctl.c     # 用户空间控制工具
+└── files/
+    ├── dns-filter.config    # UCI配置文件
+    ├── blocked-domains.txt  # 默认域名列表
+    └── dns-filter.init      # 初始化脚本
+```
+
+## 许可证
+
+Copyright (c) 2024 DNS Filter Team
+
+本程序是自由软件，您可以根据自由软件基金会发布的GNU通用公共许可证第2版的条款重新分发和/或修改它。

--- a/dns_filter/dns_filter.h
+++ b/dns_filter/dns_filter.h
@@ -1,0 +1,100 @@
+#ifndef _DNS_FILTER_H
+#define _DNS_FILTER_H
+
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/netfilter.h>
+#include <linux/netfilter_ipv4.h>
+#include <linux/ip.h>
+#include <linux/udp.h>
+#include <linux/tcp.h>
+#include <linux/skbuff.h>
+#include <linux/proc_fs.h>
+#include <linux/seq_file.h>
+#include <linux/uaccess.h>
+#include <linux/string.h>
+#include <linux/slab.h>
+#include <linux/hash.h>
+#include <linux/spinlock.h>
+#include <linux/rbtree.h>
+#include <net/ip.h>
+#include <net/udp.h>
+
+#define DNS_FILTER_VERSION "1.0"
+#define MAX_DOMAIN_LENGTH 256
+#define MAX_DOMAINS 10000
+#define DNS_PORT 53
+
+/* DNS Header Structure */
+struct dns_header {
+    u16 id;
+    u16 flags;
+    u16 qdcount;
+    u16 ancount;
+    u16 nscount;
+    u16 arcount;
+} __packed;
+
+/* DNS Question Structure */
+struct dns_question {
+    /* Domain name follows in compressed format */
+    u16 qtype;
+    u16 qclass;
+} __packed;
+
+/* Blocked domain entry */
+struct blocked_domain {
+    struct rb_node node;
+    char domain[MAX_DOMAIN_LENGTH];
+    int len;
+    u32 hit_count;
+    unsigned long last_hit;
+};
+
+/* Filter statistics */
+struct dns_filter_stats {
+    u64 total_queries;
+    u64 blocked_queries;
+    u64 allowed_queries;
+    u64 malformed_queries;
+    unsigned long start_time;
+};
+
+/* Module configuration */
+struct dns_filter_config {
+    bool enabled;
+    bool log_blocked;
+    bool log_allowed;
+    bool block_unknown;
+    u32 max_domains;
+};
+
+/* Function declarations */
+int dns_filter_init_domains(void);
+void dns_filter_cleanup_domains(void);
+int dns_filter_add_domain(const char *domain);
+int dns_filter_remove_domain(const char *domain);
+bool dns_filter_is_blocked(const char *domain);
+int dns_filter_parse_dns_name(const u8 *data, int data_len, char *name, int name_len);
+unsigned int dns_filter_hook(void *priv, struct sk_buff *skb, const struct nf_hook_state *state);
+
+/* Proc interface */
+int dns_filter_proc_init(void);
+void dns_filter_proc_cleanup(void);
+
+/* External variables */
+extern struct dns_filter_stats filter_stats;
+extern struct dns_filter_config filter_config;
+extern struct rb_root blocked_domains_tree;
+extern spinlock_t domains_lock;
+
+/* Logging macros */
+#define DNS_FILTER_INFO(fmt, args...) printk(KERN_INFO "dns_filter: " fmt, ##args)
+#define DNS_FILTER_ERR(fmt, args...) printk(KERN_ERR "dns_filter: " fmt, ##args)
+#define DNS_FILTER_DEBUG(fmt, args...) \
+    do { \
+        if (filter_config.log_blocked || filter_config.log_allowed) \
+            printk(KERN_DEBUG "dns_filter: " fmt, ##args); \
+    } while(0)
+
+#endif /* _DNS_FILTER_H */

--- a/dns_filter/dns_filter_core.c
+++ b/dns_filter/dns_filter_core.c
@@ -1,0 +1,413 @@
+#include "dns_filter.h"
+
+/* Red-black tree operations for blocked domains */
+static int domain_cmp(const char *a, const char *b)
+{
+    return strcmp(a, b);
+}
+
+static struct blocked_domain *domain_search(struct rb_root *root, const char *domain)
+{
+    struct rb_node *node = root->rb_node;
+    
+    while (node) {
+        struct blocked_domain *data = container_of(node, struct blocked_domain, node);
+        int result = domain_cmp(domain, data->domain);
+        
+        if (result < 0)
+            node = node->rb_left;
+        else if (result > 0)
+            node = node->rb_right;
+        else
+            return data;
+    }
+    return NULL;
+}
+
+static int domain_insert(struct rb_root *root, struct blocked_domain *data)
+{
+    struct rb_node **new = &(root->rb_node), *parent = NULL;
+    
+    while (*new) {
+        struct blocked_domain *this = container_of(*new, struct blocked_domain, node);
+        int result = domain_cmp(data->domain, this->domain);
+        
+        parent = *new;
+        if (result < 0)
+            new = &((*new)->rb_left);
+        else if (result > 0)
+            new = &((*new)->rb_right);
+        else
+            return -EEXIST;
+    }
+    
+    rb_link_node(&data->node, parent, new);
+    rb_insert_color(&data->node, root);
+    return 0;
+}
+
+static void domain_erase(struct rb_root *root, struct blocked_domain *data)
+{
+    rb_erase(&data->node, root);
+}
+
+/* Initialize domain storage */
+int dns_filter_init_domains(void)
+{
+    blocked_domains_tree = RB_ROOT;
+    return 0;
+}
+
+/* Cleanup domain storage */
+void dns_filter_cleanup_domains(void)
+{
+    struct rb_node *node;
+    struct blocked_domain *domain;
+    unsigned long flags;
+    
+    spin_lock_irqsave(&domains_lock, flags);
+    
+    while ((node = rb_first(&blocked_domains_tree))) {
+        domain = rb_entry(node, struct blocked_domain, node);
+        rb_erase(node, &blocked_domains_tree);
+        kfree(domain);
+    }
+    
+    spin_unlock_irqrestore(&domains_lock, flags);
+}
+
+/* Add a domain to the blocked list */
+int dns_filter_add_domain(const char *domain)
+{
+    struct blocked_domain *new_domain;
+    unsigned long flags;
+    int ret;
+    
+    if (!domain || strlen(domain) >= MAX_DOMAIN_LENGTH)
+        return -EINVAL;
+        
+    new_domain = kmalloc(sizeof(struct blocked_domain), GFP_KERNEL);
+    if (!new_domain)
+        return -ENOMEM;
+        
+    strncpy(new_domain->domain, domain, MAX_DOMAIN_LENGTH - 1);
+    new_domain->domain[MAX_DOMAIN_LENGTH - 1] = '\0';
+    new_domain->len = strlen(new_domain->domain);
+    new_domain->hit_count = 0;
+    new_domain->last_hit = 0;
+    
+    spin_lock_irqsave(&domains_lock, flags);
+    ret = domain_insert(&blocked_domains_tree, new_domain);
+    spin_unlock_irqrestore(&domains_lock, flags);
+    
+    if (ret) {
+        kfree(new_domain);
+        return ret;
+    }
+    
+    DNS_FILTER_INFO("Added blocked domain: %s\n", domain);
+    return 0;
+}
+
+/* Remove a domain from the blocked list */
+int dns_filter_remove_domain(const char *domain)
+{
+    struct blocked_domain *found;
+    unsigned long flags;
+    
+    if (!domain)
+        return -EINVAL;
+        
+    spin_lock_irqsave(&domains_lock, flags);
+    found = domain_search(&blocked_domains_tree, domain);
+    if (found) {
+        domain_erase(&blocked_domains_tree, found);
+        spin_unlock_irqrestore(&domains_lock, flags);
+        kfree(found);
+        DNS_FILTER_INFO("Removed blocked domain: %s\n", domain);
+        return 0;
+    }
+    spin_unlock_irqrestore(&domains_lock, flags);
+    
+    return -ENOENT;
+}
+
+/* Check if a domain should be blocked */
+bool dns_filter_is_blocked(const char *domain)
+{
+    struct blocked_domain *found;
+    unsigned long flags;
+    char *subdomain;
+    
+    if (!domain)
+        return false;
+        
+    spin_lock_irqsave(&domains_lock, flags);
+    
+    /* First check exact match */
+    found = domain_search(&blocked_domains_tree, domain);
+    if (found) {
+        found->hit_count++;
+        found->last_hit = jiffies;
+        spin_unlock_irqrestore(&domains_lock, flags);
+        return true;
+    }
+    
+    /* Check subdomains (e.g., block *.example.com if example.com is blocked) */
+    subdomain = strchr(domain, '.');
+    while (subdomain && *subdomain == '.') {
+        subdomain++;
+        found = domain_search(&blocked_domains_tree, subdomain);
+        if (found) {
+            found->hit_count++;
+            found->last_hit = jiffies;
+            spin_unlock_irqrestore(&domains_lock, flags);
+            return true;
+        }
+        subdomain = strchr(subdomain, '.');
+    }
+    
+    spin_unlock_irqrestore(&domains_lock, flags);
+    return false;
+}
+
+/* Proc interface implementation */
+static struct proc_dir_entry *proc_dns_filter;
+static struct proc_dir_entry *proc_dns_filter_stats;
+static struct proc_dir_entry *proc_dns_filter_config;
+static struct proc_dir_entry *proc_dns_filter_domains;
+
+/* Stats proc file operations */
+static int dns_filter_stats_show(struct seq_file *m, void *v)
+{
+    unsigned long uptime = (jiffies - filter_stats.start_time) / HZ;
+    
+    seq_printf(m, "DNS Filter Statistics:\n");
+    seq_printf(m, "Uptime: %lu seconds\n", uptime);
+    seq_printf(m, "Total queries: %llu\n", filter_stats.total_queries);
+    seq_printf(m, "Blocked queries: %llu\n", filter_stats.blocked_queries);
+    seq_printf(m, "Allowed queries: %llu\n", filter_stats.allowed_queries);
+    seq_printf(m, "Malformed queries: %llu\n", filter_stats.malformed_queries);
+    
+    if (filter_stats.total_queries > 0) {
+        seq_printf(m, "Block rate: %llu.%02llu%%\n",
+                   (filter_stats.blocked_queries * 100) / filter_stats.total_queries,
+                   ((filter_stats.blocked_queries * 10000) / filter_stats.total_queries) % 100);
+    }
+    
+    return 0;
+}
+
+static int dns_filter_stats_open(struct inode *inode, struct file *file)
+{
+    return single_open(file, dns_filter_stats_show, NULL);
+}
+
+static const struct proc_ops dns_filter_stats_ops = {
+    .proc_open = dns_filter_stats_open,
+    .proc_read = seq_read,
+    .proc_lseek = seq_lseek,
+    .proc_release = single_release,
+};
+
+/* Config proc file operations */
+static int dns_filter_config_show(struct seq_file *m, void *v)
+{
+    seq_printf(m, "enabled=%d\n", filter_config.enabled ? 1 : 0);
+    seq_printf(m, "log_blocked=%d\n", filter_config.log_blocked ? 1 : 0);
+    seq_printf(m, "log_allowed=%d\n", filter_config.log_allowed ? 1 : 0);
+    seq_printf(m, "block_unknown=%d\n", filter_config.block_unknown ? 1 : 0);
+    seq_printf(m, "max_domains=%u\n", filter_config.max_domains);
+    return 0;
+}
+
+static int dns_filter_config_open(struct inode *inode, struct file *file)
+{
+    return single_open(file, dns_filter_config_show, NULL);
+}
+
+static ssize_t dns_filter_config_write(struct file *file, const char __user *buffer,
+                                       size_t count, loff_t *pos)
+{
+    char buf[256];
+    char *line, *key, *value;
+    int val;
+    
+    if (count >= sizeof(buf))
+        return -EINVAL;
+        
+    if (copy_from_user(buf, buffer, count))
+        return -EFAULT;
+        
+    buf[count] = '\0';
+    line = buf;
+    
+    while ((line = strsep(&buf, "\n")) != NULL) {
+        if (strlen(line) == 0)
+            continue;
+            
+        key = strsep(&line, "=");
+        value = line;
+        
+        if (!key || !value)
+            continue;
+            
+        if (kstrtoint(value, 10, &val))
+            continue;
+            
+        if (strcmp(key, "enabled") == 0) {
+            filter_config.enabled = val ? true : false;
+        } else if (strcmp(key, "log_blocked") == 0) {
+            filter_config.log_blocked = val ? true : false;
+        } else if (strcmp(key, "log_allowed") == 0) {
+            filter_config.log_allowed = val ? true : false;
+        } else if (strcmp(key, "block_unknown") == 0) {
+            filter_config.block_unknown = val ? true : false;
+        } else if (strcmp(key, "max_domains") == 0 && val > 0) {
+            filter_config.max_domains = val;
+        }
+    }
+    
+    return count;
+}
+
+static const struct proc_ops dns_filter_config_ops = {
+    .proc_open = dns_filter_config_open,
+    .proc_read = seq_read,
+    .proc_write = dns_filter_config_write,
+    .proc_lseek = seq_lseek,
+    .proc_release = single_release,
+};
+
+/* Domains proc file operations */
+static void *dns_filter_domains_start(struct seq_file *m, loff_t *pos)
+{
+    struct rb_node *node;
+    loff_t n = *pos;
+    
+    spin_lock(&domains_lock);
+    
+    for (node = rb_first(&blocked_domains_tree); node && n > 0; node = rb_next(node), n--)
+        ;
+        
+    return node;
+}
+
+static void *dns_filter_domains_next(struct seq_file *m, void *v, loff_t *pos)
+{
+    (*pos)++;
+    return rb_next((struct rb_node *)v);
+}
+
+static void dns_filter_domains_stop(struct seq_file *m, void *v)
+{
+    spin_unlock(&domains_lock);
+}
+
+static int dns_filter_domains_show(struct seq_file *m, void *v)
+{
+    struct rb_node *node = v;
+    struct blocked_domain *domain = rb_entry(node, struct blocked_domain, node);
+    
+    seq_printf(m, "%s %u %lu\n", domain->domain, domain->hit_count, domain->last_hit);
+    return 0;
+}
+
+static const struct seq_operations dns_filter_domains_seq_ops = {
+    .start = dns_filter_domains_start,
+    .next = dns_filter_domains_next,
+    .stop = dns_filter_domains_stop,
+    .show = dns_filter_domains_show,
+};
+
+static int dns_filter_domains_open(struct inode *inode, struct file *file)
+{
+    return seq_open(file, &dns_filter_domains_seq_ops);
+}
+
+static ssize_t dns_filter_domains_write(struct file *file, const char __user *buffer,
+                                        size_t count, loff_t *pos)
+{
+    char buf[MAX_DOMAIN_LENGTH + 10];
+    char *line, *cmd, *domain;
+    
+    if (count >= sizeof(buf))
+        return -EINVAL;
+        
+    if (copy_from_user(buf, buffer, count))
+        return -EFAULT;
+        
+    buf[count] = '\0';
+    line = buf;
+    
+    cmd = strsep(&line, " ");
+    domain = line;
+    
+    if (!cmd || !domain)
+        return -EINVAL;
+        
+    /* Remove trailing newline */
+    if (domain[strlen(domain) - 1] == '\n')
+        domain[strlen(domain) - 1] = '\0';
+        
+    if (strcmp(cmd, "add") == 0) {
+        dns_filter_add_domain(domain);
+    } else if (strcmp(cmd, "del") == 0) {
+        dns_filter_remove_domain(domain);
+    } else {
+        return -EINVAL;
+    }
+    
+    return count;
+}
+
+static const struct proc_ops dns_filter_domains_ops = {
+    .proc_open = dns_filter_domains_open,
+    .proc_read = seq_read,
+    .proc_write = dns_filter_domains_write,
+    .proc_lseek = seq_lseek,
+    .proc_release = seq_release,
+};
+
+/* Initialize proc interface */
+int dns_filter_proc_init(void)
+{
+    proc_dns_filter = proc_mkdir("dns_filter", NULL);
+    if (!proc_dns_filter)
+        return -ENOMEM;
+        
+    proc_dns_filter_stats = proc_create("stats", 0644, proc_dns_filter, &dns_filter_stats_ops);
+    if (!proc_dns_filter_stats)
+        goto err_stats;
+        
+    proc_dns_filter_config = proc_create("config", 0644, proc_dns_filter, &dns_filter_config_ops);
+    if (!proc_dns_filter_config)
+        goto err_config;
+        
+    proc_dns_filter_domains = proc_create("domains", 0644, proc_dns_filter, &dns_filter_domains_ops);
+    if (!proc_dns_filter_domains)
+        goto err_domains;
+        
+    return 0;
+    
+err_domains:
+    proc_remove(proc_dns_filter_config);
+err_config:
+    proc_remove(proc_dns_filter_stats);
+err_stats:
+    proc_remove(proc_dns_filter);
+    return -ENOMEM;
+}
+
+/* Cleanup proc interface */
+void dns_filter_proc_cleanup(void)
+{
+    if (proc_dns_filter_domains)
+        proc_remove(proc_dns_filter_domains);
+    if (proc_dns_filter_config)
+        proc_remove(proc_dns_filter_config);
+    if (proc_dns_filter_stats)
+        proc_remove(proc_dns_filter_stats);
+    if (proc_dns_filter)
+        proc_remove(proc_dns_filter);
+}

--- a/dns_filter/dns_filter_ctl.c
+++ b/dns_filter/dns_filter_ctl.c
@@ -1,0 +1,332 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <getopt.h>
+#include <sys/stat.h>
+
+#define PROC_DNS_FILTER_CONFIG "/proc/dns_filter/config"
+#define PROC_DNS_FILTER_DOMAINS "/proc/dns_filter/domains"
+#define PROC_DNS_FILTER_STATS "/proc/dns_filter/stats"
+#define CONFIG_FILE "/etc/dns-filter/blocked-domains.txt"
+
+static void usage(const char *program)
+{
+    printf("DNS Filter Control Tool v1.0\n");
+    printf("Usage: %s [options]\n\n", program);
+    printf("Options:\n");
+    printf("  -h, --help           Show this help message\n");
+    printf("  -s, --status         Show filter status and statistics\n");
+    printf("  -e, --enable         Enable DNS filtering\n");
+    printf("  -d, --disable        Disable DNS filtering\n");
+    printf("  -a, --add DOMAIN     Add domain to block list\n");
+    printf("  -r, --remove DOMAIN  Remove domain from block list\n");
+    printf("  -l, --list           List all blocked domains\n");
+    printf("  -L, --load FILE      Load domains from file (default: %s)\n", CONFIG_FILE);
+    printf("  -c, --clear          Clear all blocked domains\n");
+    printf("  --log-blocked [0|1]  Enable/disable logging of blocked queries\n");
+    printf("  --log-allowed [0|1]  Enable/disable logging of allowed queries\n");
+    printf("  --stats              Show detailed statistics\n");
+    printf("\nExamples:\n");
+    printf("  %s --add example.com\n", program);
+    printf("  %s --remove example.com\n", program);
+    printf("  %s --load /etc/dns-filter/blocked-domains.txt\n", program);
+    printf("  %s --enable --log-blocked 1\n", program);
+    printf("  %s --stats\n", program);
+}
+
+static int write_to_proc(const char *path, const char *data)
+{
+    FILE *fp = fopen(path, "w");
+    if (!fp) {
+        fprintf(stderr, "Error: Cannot open %s: %s\n", path, strerror(errno));
+        return -1;
+    }
+    
+    if (fprintf(fp, "%s", data) < 0) {
+        fprintf(stderr, "Error: Cannot write to %s: %s\n", path, strerror(errno));
+        fclose(fp);
+        return -1;
+    }
+    
+    fclose(fp);
+    return 0;
+}
+
+static int read_from_proc(const char *path)
+{
+    FILE *fp = fopen(path, "r");
+    char buffer[4096];
+    
+    if (!fp) {
+        fprintf(stderr, "Error: Cannot open %s: %s\n", path, strerror(errno));
+        return -1;
+    }
+    
+    while (fgets(buffer, sizeof(buffer), fp)) {
+        printf("%s", buffer);
+    }
+    
+    fclose(fp);
+    return 0;
+}
+
+static int add_domain(const char *domain)
+{
+    char cmd[512];
+    
+    if (!domain || strlen(domain) == 0) {
+        fprintf(stderr, "Error: Domain cannot be empty\n");
+        return -1;
+    }
+    
+    snprintf(cmd, sizeof(cmd), "add %s\n", domain);
+    
+    if (write_to_proc(PROC_DNS_FILTER_DOMAINS, cmd) == 0) {
+        printf("Added domain: %s\n", domain);
+        return 0;
+    }
+    
+    return -1;
+}
+
+static int remove_domain(const char *domain)
+{
+    char cmd[512];
+    
+    if (!domain || strlen(domain) == 0) {
+        fprintf(stderr, "Error: Domain cannot be empty\n");
+        return -1;
+    }
+    
+    snprintf(cmd, sizeof(cmd), "del %s\n", domain);
+    
+    if (write_to_proc(PROC_DNS_FILTER_DOMAINS, cmd) == 0) {
+        printf("Removed domain: %s\n", domain);
+        return 0;
+    }
+    
+    return -1;
+}
+
+static int list_domains(void)
+{
+    printf("Blocked domains (format: domain hit_count last_hit_jiffies):\n");
+    return read_from_proc(PROC_DNS_FILTER_DOMAINS);
+}
+
+static int show_stats(void)
+{
+    return read_from_proc(PROC_DNS_FILTER_STATS);
+}
+
+static int show_status(void)
+{
+    printf("Current DNS Filter Configuration:\n");
+    read_from_proc(PROC_DNS_FILTER_CONFIG);
+    printf("\n");
+    return show_stats();
+}
+
+static int set_config(const char *key, int value)
+{
+    char cmd[128];
+    
+    snprintf(cmd, sizeof(cmd), "%s=%d\n", key, value);
+    
+    if (write_to_proc(PROC_DNS_FILTER_CONFIG, cmd) == 0) {
+        printf("Set %s = %d\n", key, value);
+        return 0;
+    }
+    
+    return -1;
+}
+
+static int enable_filter(void)
+{
+    return set_config("enabled", 1);
+}
+
+static int disable_filter(void)
+{
+    return set_config("enabled", 0);
+}
+
+static int load_domains_from_file(const char *filename)
+{
+    FILE *fp;
+    char line[512];
+    int count = 0;
+    int errors = 0;
+    
+    if (!filename) {
+        filename = CONFIG_FILE;
+    }
+    
+    fp = fopen(filename, "r");
+    if (!fp) {
+        fprintf(stderr, "Error: Cannot open %s: %s\n", filename, strerror(errno));
+        return -1;
+    }
+    
+    printf("Loading domains from %s...\n", filename);
+    
+    while (fgets(line, sizeof(line), fp)) {
+        char *domain = line;
+        char *comment;
+        
+        /* Remove trailing newline */
+        if (line[strlen(line) - 1] == '\n') {
+            line[strlen(line) - 1] = '\0';
+        }
+        
+        /* Skip empty lines and comments */
+        if (strlen(line) == 0 || line[0] == '#') {
+            continue;
+        }
+        
+        /* Remove inline comments */
+        comment = strchr(line, '#');
+        if (comment) {
+            *comment = '\0';
+        }
+        
+        /* Trim whitespace */
+        while (*domain == ' ' || *domain == '\t') {
+            domain++;
+        }
+        
+        if (strlen(domain) == 0) {
+            continue;
+        }
+        
+        /* Remove trailing whitespace */
+        char *end = domain + strlen(domain) - 1;
+        while (end > domain && (*end == ' ' || *end == '\t')) {
+            *end = '\0';
+            end--;
+        }
+        
+        if (add_domain(domain) == 0) {
+            count++;
+        } else {
+            errors++;
+        }
+    }
+    
+    fclose(fp);
+    
+    printf("Loaded %d domains from %s", count, filename);
+    if (errors > 0) {
+        printf(" (%d errors)", errors);
+    }
+    printf("\n");
+    
+    return 0;
+}
+
+static int clear_domains(void)
+{
+    FILE *fp;
+    char line[512];
+    char domain[256];
+    int count = 0;
+    
+    /* First, get list of all domains */
+    fp = fopen(PROC_DNS_FILTER_DOMAINS, "r");
+    if (!fp) {
+        fprintf(stderr, "Error: Cannot open %s: %s\n", PROC_DNS_FILTER_DOMAINS, strerror(errno));
+        return -1;
+    }
+    
+    printf("Clearing all blocked domains...\n");
+    
+    while (fgets(line, sizeof(line), fp)) {
+        if (sscanf(line, "%255s", domain) == 1) {
+            if (remove_domain(domain) == 0) {
+                count++;
+            }
+        }
+    }
+    
+    fclose(fp);
+    
+    printf("Cleared %d domains\n", count);
+    return 0;
+}
+
+int main(int argc, char *argv[])
+{
+    int opt;
+    int option_index = 0;
+    
+    static struct option long_options[] = {
+        {"help",        no_argument,       0, 'h'},
+        {"status",      no_argument,       0, 's'},
+        {"enable",      no_argument,       0, 'e'},
+        {"disable",     no_argument,       0, 'd'},
+        {"add",         required_argument, 0, 'a'},
+        {"remove",      required_argument, 0, 'r'},
+        {"list",        no_argument,       0, 'l'},
+        {"load",        required_argument, 0, 'L'},
+        {"clear",       no_argument,       0, 'c'},
+        {"log-blocked", required_argument, 0, 1001},
+        {"log-allowed", required_argument, 0, 1002},
+        {"stats",       no_argument,       0, 1003},
+        {0, 0, 0, 0}
+    };
+    
+    if (argc == 1) {
+        usage(argv[0]);
+        return 0;
+    }
+    
+    while ((opt = getopt_long(argc, argv, "hseda:r:lL:c", long_options, &option_index)) != -1) {
+        switch (opt) {
+        case 'h':
+            usage(argv[0]);
+            return 0;
+            
+        case 's':
+            return show_status();
+            
+        case 'e':
+            return enable_filter();
+            
+        case 'd':
+            return disable_filter();
+            
+        case 'a':
+            return add_domain(optarg);
+            
+        case 'r':
+            return remove_domain(optarg);
+            
+        case 'l':
+            return list_domains();
+            
+        case 'L':
+            return load_domains_from_file(optarg);
+            
+        case 'c':
+            return clear_domains();
+            
+        case 1001:
+            return set_config("log_blocked", atoi(optarg));
+            
+        case 1002:
+            return set_config("log_allowed", atoi(optarg));
+            
+        case 1003:
+            return show_stats();
+            
+        default:
+            fprintf(stderr, "Try '%s --help' for more information.\n", argv[0]);
+            return 1;
+        }
+    }
+    
+    return 0;
+}

--- a/dns_filter/dns_filter_main.c
+++ b/dns_filter/dns_filter_main.c
@@ -1,0 +1,214 @@
+#include "dns_filter.h"
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("DNS Filter Team");
+MODULE_DESCRIPTION("DNS Site Filtering Module for OpenWrt");
+MODULE_VERSION(DNS_FILTER_VERSION);
+
+/* Global variables */
+struct dns_filter_stats filter_stats;
+struct dns_filter_config filter_config = {
+    .enabled = true,
+    .log_blocked = false,
+    .log_allowed = false,
+    .block_unknown = false,
+    .max_domains = MAX_DOMAINS
+};
+
+struct rb_root blocked_domains_tree = RB_ROOT;
+DEFINE_SPINLOCK(domains_lock);
+
+/* Netfilter hook operations */
+static struct nf_hook_ops dns_filter_ops = {
+    .hook = dns_filter_hook,
+    .pf = PF_INET,
+    .hooknum = NF_INET_PRE_ROUTING,
+    .priority = NF_IP_PRI_FIRST,
+};
+
+/* Parse DNS name from packet data */
+int dns_filter_parse_dns_name(const u8 *data, int data_len, char *name, int name_len)
+{
+    int pos = 0;
+    int name_pos = 0;
+    int len;
+    bool first = true;
+    
+    if (!data || !name || data_len < 1 || name_len < 1)
+        return -EINVAL;
+        
+    while (pos < data_len && name_pos < name_len - 1) {
+        len = data[pos++];
+        
+        /* End of name */
+        if (len == 0)
+            break;
+            
+        /* Check for compression (not handled in this simple implementation) */
+        if ((len & 0xC0) == 0xC0) {
+            DNS_FILTER_DEBUG("DNS compression detected, skipping\n");
+            return -ENOTSUP;
+        }
+        
+        /* Check bounds */
+        if (pos + len > data_len || name_pos + len + 1 >= name_len)
+            return -EINVAL;
+            
+        /* Add dot separator (except for first label) */
+        if (!first) {
+            name[name_pos++] = '.';
+        }
+        first = false;
+        
+        /* Copy label */
+        memcpy(name + name_pos, data + pos, len);
+        name_pos += len;
+        pos += len;
+    }
+    
+    name[name_pos] = '\0';
+    return name_pos;
+}
+
+/* Main netfilter hook function */
+unsigned int dns_filter_hook(void *priv, struct sk_buff *skb, const struct nf_hook_state *state)
+{
+    struct iphdr *iph;
+    struct udphdr *udph;
+    struct dns_header *dnsh;
+    char domain_name[MAX_DOMAIN_LENGTH];
+    u8 *dns_data;
+    int dns_data_len;
+    int name_len;
+    
+    if (!filter_config.enabled)
+        return NF_ACCEPT;
+        
+    /* Basic packet validation */
+    if (!skb)
+        return NF_ACCEPT;
+        
+    iph = ip_hdr(skb);
+    if (!iph || iph->protocol != IPPROTO_UDP)
+        return NF_ACCEPT;
+        
+    /* Check if packet is long enough for UDP header */
+    if (skb->len < sizeof(struct iphdr) + sizeof(struct udphdr))
+        return NF_ACCEPT;
+        
+    udph = udp_hdr(skb);
+    if (!udph)
+        return NF_ACCEPT;
+        
+    /* Check if this is a DNS query (destination port 53) */
+    if (ntohs(udph->dest) != DNS_PORT)
+        return NF_ACCEPT;
+        
+    filter_stats.total_queries++;
+    
+    /* Calculate DNS data offset and length */
+    dns_data = (u8 *)udph + sizeof(struct udphdr);
+    dns_data_len = ntohs(udph->len) - sizeof(struct udphdr);
+    
+    /* Validate DNS packet size */
+    if (dns_data_len < sizeof(struct dns_header)) {
+        filter_stats.malformed_queries++;
+        return NF_ACCEPT;
+    }
+    
+    dnsh = (struct dns_header *)dns_data;
+    
+    /* Check if this is a query (QR bit = 0) and has questions */
+    if ((ntohs(dnsh->flags) & 0x8000) || ntohs(dnsh->qdcount) == 0)
+        return NF_ACCEPT;
+        
+    /* Parse the first question domain name */
+    name_len = dns_filter_parse_dns_name(dns_data + sizeof(struct dns_header),
+                                        dns_data_len - sizeof(struct dns_header),
+                                        domain_name, sizeof(domain_name));
+    
+    if (name_len <= 0) {
+        filter_stats.malformed_queries++;
+        DNS_FILTER_DEBUG("Failed to parse DNS name from %pI4\n", &iph->saddr);
+        return NF_ACCEPT;
+    }
+    
+    /* Check if domain should be blocked */
+    if (dns_filter_is_blocked(domain_name)) {
+        filter_stats.blocked_queries++;
+        
+        if (filter_config.log_blocked) {
+            DNS_FILTER_INFO("BLOCKED: %s from %pI4\n", domain_name, &iph->saddr);
+        }
+        
+        /* Drop the packet to block the DNS query */
+        return NF_DROP;
+    }
+    
+    filter_stats.allowed_queries++;
+    
+    if (filter_config.log_allowed) {
+        DNS_FILTER_DEBUG("ALLOWED: %s from %pI4\n", domain_name, &iph->saddr);
+    }
+    
+    return NF_ACCEPT;
+}
+
+/* Module initialization */
+static int __init dns_filter_init(void)
+{
+    int ret;
+    
+    DNS_FILTER_INFO("DNS Filter Module v%s loading...\n", DNS_FILTER_VERSION);
+    
+    /* Initialize statistics */
+    memset(&filter_stats, 0, sizeof(filter_stats));
+    filter_stats.start_time = jiffies;
+    
+    /* Initialize domain storage */
+    ret = dns_filter_init_domains();
+    if (ret) {
+        DNS_FILTER_ERR("Failed to initialize domains storage: %d\n", ret);
+        return ret;
+    }
+    
+    /* Register netfilter hook */
+    ret = nf_register_net_hook(&init_net, &dns_filter_ops);
+    if (ret) {
+        DNS_FILTER_ERR("Failed to register netfilter hook: %d\n", ret);
+        dns_filter_cleanup_domains();
+        return ret;
+    }
+    
+    /* Initialize proc interface */
+    ret = dns_filter_proc_init();
+    if (ret) {
+        DNS_FILTER_ERR("Failed to initialize proc interface: %d\n", ret);
+        nf_unregister_net_hook(&init_net, &dns_filter_ops);
+        dns_filter_cleanup_domains();
+        return ret;
+    }
+    
+    DNS_FILTER_INFO("DNS Filter Module loaded successfully\n");
+    return 0;
+}
+
+/* Module cleanup */
+static void __exit dns_filter_exit(void)
+{
+    DNS_FILTER_INFO("DNS Filter Module unloading...\n");
+    
+    /* Cleanup proc interface */
+    dns_filter_proc_cleanup();
+    
+    /* Unregister netfilter hook */
+    nf_unregister_net_hook(&init_net, &dns_filter_ops);
+    
+    /* Cleanup domain storage */
+    dns_filter_cleanup_domains();
+    
+    DNS_FILTER_INFO("DNS Filter Module unloaded\n");
+}
+
+module_init(dns_filter_init);
+module_exit(dns_filter_exit);

--- a/dns_filter/files/blocked-domains.txt
+++ b/dns_filter/files/blocked-domains.txt
@@ -1,0 +1,31 @@
+# DNS Filter - Blocked Domains Configuration
+# 
+# Format: One domain per line
+# Comments start with #
+# Subdomains are automatically blocked (e.g., blocking example.com also blocks www.example.com)
+#
+# Example malicious and ad domains (uncomment to enable)
+
+# Malware and phishing domains
+# malware.com
+# phishing-site.net
+# fake-bank.org
+
+# Advertisement and tracking domains
+# doubleclick.net
+# googleads.com
+# googlesyndication.com
+# googleadservices.com
+# facebook.com  # Uncomment to block Facebook
+# twitter.com   # Uncomment to block Twitter
+
+# Adult content (uncomment if needed)
+# pornhub.com
+# xvideos.com
+
+# Gambling sites (uncomment if needed)
+# bet365.com
+# pokerstars.com
+
+# Add your custom blocked domains below:
+# example-blocked.com

--- a/dns_filter/files/dns-filter.config
+++ b/dns_filter/files/dns-filter.config
@@ -1,0 +1,8 @@
+config dns-filter 'config'
+	option enabled '1'
+	option log_blocked '0'
+	option log_allowed '0'
+	option block_unknown '0'
+	option max_domains '10000'
+	option domains_file '/etc/dns-filter/blocked-domains.txt'
+	option auto_load_domains '1'

--- a/dns_filter/files/dns-filter.init
+++ b/dns_filter/files/dns-filter.init
@@ -1,0 +1,116 @@
+#!/bin/sh /etc/rc.common
+
+START=95
+STOP=15
+
+USE_PROCD=1
+PROG=/usr/sbin/dns-filter-ctl
+
+load_config() {
+	config_load dns-filter
+	
+	config_get enabled config enabled 1
+	config_get log_blocked config log_blocked 0
+	config_get log_allowed config log_allowed 0
+	config_get block_unknown config block_unknown 0
+	config_get max_domains config max_domains 10000
+	config_get domains_file config domains_file "/etc/dns-filter/blocked-domains.txt"
+	config_get auto_load_domains config auto_load_domains 1
+}
+
+start_service() {
+	# Load configuration
+	load_config
+	
+	# Load kernel module
+	if ! lsmod | grep -q dns_filter; then
+		logger -t dns-filter "Loading dns_filter kernel module"
+		insmod /lib/modules/$(uname -r)/dns_filter.ko
+		if [ $? -ne 0 ]; then
+			logger -t dns-filter "ERROR: Failed to load dns_filter kernel module"
+			return 1
+		fi
+		sleep 1
+	fi
+	
+	# Configure the filter
+	if [ "$enabled" = "1" ]; then
+		$PROG --enable
+	else
+		$PROG --disable
+	fi
+	
+	$PROG --log-blocked $log_blocked
+	$PROG --log-allowed $log_allowed
+	
+	# Load domains from file if auto_load_domains is enabled
+	if [ "$auto_load_domains" = "1" ] && [ -f "$domains_file" ]; then
+		logger -t dns-filter "Loading domains from $domains_file"
+		$PROG --load "$domains_file"
+		if [ $? -eq 0 ]; then
+			logger -t dns-filter "Successfully loaded domains from $domains_file"
+		else
+			logger -t dns-filter "WARNING: Failed to load some domains from $domains_file"
+		fi
+	fi
+	
+	logger -t dns-filter "DNS Filter service started"
+}
+
+stop_service() {
+	# Clear all domains
+	if [ -x "$PROG" ] && lsmod | grep -q dns_filter; then
+		logger -t dns-filter "Clearing blocked domains"
+		$PROG --clear
+		
+		# Disable filter
+		$PROG --disable
+	fi
+	
+	# Unload kernel module
+	if lsmod | grep -q dns_filter; then
+		logger -t dns-filter "Unloading dns_filter kernel module"
+		rmmod dns_filter
+		if [ $? -eq 0 ]; then
+			logger -t dns-filter "DNS Filter service stopped"
+		else
+			logger -t dns-filter "WARNING: Failed to unload dns_filter kernel module"
+		fi
+	fi
+}
+
+restart() {
+	stop_service
+	sleep 2
+	start_service
+}
+
+reload_service() {
+	load_config
+	
+	# Only reload if module is loaded
+	if ! lsmod | grep -q dns_filter; then
+		logger -t dns-filter "Kernel module not loaded, starting service instead"
+		start_service
+		return
+	fi
+	
+	# Clear existing domains and reload
+	if [ "$auto_load_domains" = "1" ] && [ -f "$domains_file" ]; then
+		logger -t dns-filter "Reloading domains from $domains_file"
+		$PROG --clear
+		$PROG --load "$domains_file"
+	fi
+	
+	# Update configuration
+	if [ "$enabled" = "1" ]; then
+		$PROG --enable
+	else
+		$PROG --disable
+	fi
+	
+	$PROG --log-blocked $log_blocked
+	$PROG --log-allowed $log_allowed
+	
+	logger -t dns-filter "DNS Filter configuration reloaded"
+}

--- a/dns_filter/test_dns_filter.sh
+++ b/dns_filter/test_dns_filter.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+# DNS Filter Module Test Script
+# 用于测试DNS过滤功能是否正常工作
+
+echo "=== DNS Filter Module Test Script ==="
+echo
+
+# 检查模块是否已加载
+echo "1. 检查内核模块状态..."
+if lsmod | grep -q dns_filter; then
+    echo "✓ DNS Filter模块已加载"
+else
+    echo "✗ DNS Filter模块未加载，尝试加载..."
+    insmod /lib/modules/$(uname -r)/dns_filter.ko
+    if [ $? -eq 0 ]; then
+        echo "✓ 模块加载成功"
+    else
+        echo "✗ 模块加载失败"
+        exit 1
+    fi
+fi
+echo
+
+# 检查控制工具
+echo "2. 检查控制工具..."
+if [ -x "/usr/sbin/dns-filter-ctl" ]; then
+    echo "✓ DNS过滤控制工具可用"
+else
+    echo "✗ DNS过滤控制工具不可用"
+    exit 1
+fi
+echo
+
+# 启用过滤
+echo "3. 启用DNS过滤..."
+dns-filter-ctl --enable
+if [ $? -eq 0 ]; then
+    echo "✓ DNS过滤已启用"
+else
+    echo "✗ 启用DNS过滤失败"
+fi
+echo
+
+# 添加测试域名
+echo "4. 添加测试域名..."
+dns-filter-ctl --add test-blocked.com
+dns-filter-ctl --add malware-test.net
+dns-filter-ctl --add ad-test.org
+echo "✓ 测试域名已添加"
+echo
+
+# 列出域名
+echo "5. 当前阻止的域名列表："
+dns-filter-ctl --list
+echo
+
+# 显示状态
+echo "6. 当前状态和统计信息："
+dns-filter-ctl --status
+echo
+
+# 测试DNS查询（需要nslookup或dig工具）
+echo "7. 进行DNS查询测试..."
+echo "注意：被阻止的查询可能会超时或失败"
+echo
+
+if command -v nslookup >/dev/null 2>&1; then
+    echo "测试正常域名查询（应该成功）："
+    timeout 5 nslookup google.com 8.8.8.8
+    echo
+    
+    echo "测试被阻止的域名查询（应该失败或超时）："
+    timeout 5 nslookup test-blocked.com 8.8.8.8
+    echo
+elif command -v dig >/dev/null 2>&1; then
+    echo "测试正常域名查询（应该成功）："
+    timeout 5 dig @8.8.8.8 google.com +short
+    echo
+    
+    echo "测试被阻止的域名查询（应该失败或超时）："
+    timeout 5 dig @8.8.8.8 test-blocked.com +short
+    echo
+else
+    echo "没有可用的DNS查询工具（nslookup或dig），跳过DNS查询测试"
+fi
+
+# 显示最新统计信息
+echo "8. 测试后的统计信息："
+dns-filter-ctl --stats
+echo
+
+# 清理测试域名
+echo "9. 清理测试域名..."
+dns-filter-ctl --remove test-blocked.com
+dns-filter-ctl --remove malware-test.net  
+dns-filter-ctl --remove ad-test.org
+echo "✓ 测试域名已清理"
+echo
+
+echo "=== 测试完成 ==="
+echo "如果看到DNS查询被阻止（超时或失败），说明过滤功能正常工作。"
+echo "即使用户设置了8.8.8.8等公共DNS，被阻止的域名仍然无法解析。"
+echo
+echo "使用以下命令管理DNS过滤："
+echo "  dns-filter-ctl --help              # 查看帮助"
+echo "  dns-filter-ctl --status            # 查看状态"
+echo "  dns-filter-ctl --add domain.com    # 添加阻止域名"
+echo "  dns-filter-ctl --list              # 列出阻止域名"
+echo "  /etc/init.d/dns-filter start       # 启动服务"


### PR DESCRIPTION
Add a kernel-level DNS filtering module to OpenWrt to enforce site blocking regardless of user-configured DNS servers.

This module intercepts all outgoing DNS queries at the `NF_INET_PRE_ROUTING` stage using Netfilter, parses the requested domain, and blocks it if it matches a list of forbidden domains. This ensures that site filtering remains effective even when users manually configure public DNS servers (e.g., 8.8.8.8 or 114.114.114.114), bypassing the router's default DNS settings.

---
<a href="https://cursor.com/background-agent?bcId=bc-1a3b101d-12af-4e79-8734-2849fe7fb178">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1a3b101d-12af-4e79-8734-2849fe7fb178">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>